### PR TITLE
fix!: updated default pull policy to PullPolicy.IF_NOT_PRESENT

### DIFF
--- a/src/main/java/io/kestra/plugin/modal/cli/ModalCLI.java
+++ b/src/main/java/io/kestra/plugin/modal/cli/ModalCLI.java
@@ -10,6 +10,7 @@ import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
 import io.kestra.plugin.scripts.exec.scripts.models.ScriptOutput;
 import io.kestra.plugin.scripts.exec.scripts.runners.CommandsWrapper;
 import io.kestra.plugin.scripts.runner.docker.Docker;
+import io.kestra.plugin.scripts.runner.docker.PullPolicy;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import lombok.*;
@@ -217,7 +218,10 @@ public class ModalCLI extends Task implements RunnableTask<ScriptOutput>, Namesp
     @PluginProperty
     @Builder.Default
     @Valid
-    private TaskRunner<?> taskRunner = Docker.instance();
+    private TaskRunner<?> taskRunner = Docker.builder()
+        .type(Docker.class.getName())
+        .pullPolicy(Property.of(PullPolicy.IF_NOT_PRESENT))
+        .build();
 
     @Schema(title = "The task runner container image, only used if the task runner is container-based.")
     @Builder.Default


### PR DESCRIPTION
BREAKING CHANGE: in accordance with new Docker Hub pull policy regulation, the default kestra pull policy will change from ALWAYS to IF_NOT_PRESENT
