### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/modal/cli/ModalCLI.java
+++ b/src/main/java/io/kestra/plugin/modal/cli/ModalCLI.java
@@ -201,10 +201,11 @@ public class ModalCLI extends Task implements RunnableTask<ScriptOutput>, Namesp
         title = "Additional environment variables",
         description = "Key-value pairs injected into the process environment; supports dynamic expressions."
     )
-    @PluginProperty(group = "execution", 
+    @PluginProperty(group = "execution",
         additionalProperties = String.class,
         dynamic = true
     )
+    @ToString.Exclude
     protected Map<String, String> env;
 
     @Schema(

--- a/src/test/java/io/kestra/plugin/modal/cli/ModalCLITest.java
+++ b/src/test/java/io/kestra/plugin/modal/cli/ModalCLITest.java
@@ -19,12 +19,33 @@ import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.containsString;
 
 @KestraTest
 class ModalCLITest {
 
     @Inject
     private RunContextFactory runContextFactory;
+
+    @Test
+    void toStringDoesNotExposeEnvSecrets() {
+        ModalCLI runner = ModalCLI.builder()
+            .id(IdUtils.create())
+            .type(ModalCLI.class.getName())
+            .commands(Property.ofValue(List.of("modal --version")))
+            .env(Map.of(
+                "MODAL_TOKEN_ID", "super-secret-token-id",
+                "MODAL_TOKEN_SECRET", "super-secret-token-secret"
+            ))
+            .build();
+
+        String representation = runner.toString();
+
+        assertThat(representation, not(containsString("super-secret-token-id")));
+        assertThat(representation, not(containsString("super-secret-token-secret")));
+        assertThat(representation, not(containsString("MODAL_TOKEN_ID")));
+    }
 
     @Test
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — `@ToString` exposes env map containing Modal API credentials — `src/main/java/io/kestra/plugin/modal/cli/ModalCLI.java:24` (env field at line 208) — Added `@ToString.Exclude` on the `env` field so Lombok-generated `toString()` no longer serializes `MODAL_TOKEN_ID`/`MODAL_TOKEN_SECRET` (or any other env value) into logs, exception messages, or diagnostics. Added a unit test (`toStringDoesNotExposeEnvSecrets`) asserting the rendered `toString()` does not contain injected secret values or the env keys.

No CRITICAL, MEDIUM, or LOW findings were reported in the audit EPIC for this repository.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-modal/issues/84
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
